### PR TITLE
Fix kitodo/kitodo-presentation#317 - use better / higher resolution

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3611,7 +3611,9 @@ olx.layer.ImageOptions.prototype.maxResolution;
  *     extent: (ol.Extent|undefined),
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined),
- *     useInterimTilesOnError: (boolean|undefined)}}
+ *     useInterimTilesOnError: (boolean|undefined),
+ *     zDirection: (number|undefined)}}
+ *
  * @api
  */
 olx.layer.TileOptions;
@@ -3692,6 +3694,17 @@ olx.layer.TileOptions.prototype.maxResolution;
  * @api stable
  */
 olx.layer.TileOptions.prototype.useInterimTilesOnError;
+
+
+/**
+ * Indicate which resolution should be used by a renderer if the views resolution
+ * does not match any resolution of the tile source.
+ * If 0, the nearest resolution will be used. If 1, the nearest lower resolution
+ * will be used. If -1, the nearest higher resolution will be used.
+ * @type {number|undefined}
+ * @api
+ */
+olx.layer.TileOptions.prototype.zDirection;
 
 
 /**

--- a/src/ol/layer/tilelayer.js
+++ b/src/ol/layer/tilelayer.js
@@ -10,7 +10,8 @@ goog.require('ol.object');
  */
 ol.layer.TileProperty = {
   PRELOAD: 'preload',
-  USE_INTERIM_TILES_ON_ERROR: 'useInterimTilesOnError'
+  USE_INTERIM_TILES_ON_ERROR: 'useInterimTilesOnError',
+  ZDIRECTION: 'zDirection'
 };
 
 
@@ -35,11 +36,13 @@ ol.layer.Tile = function(opt_options) {
 
   delete baseOptions.preload;
   delete baseOptions.useInterimTilesOnError;
+  delete baseOptions.zDirection;
   goog.base(this,  /** @type {olx.layer.LayerOptions} */ (baseOptions));
 
   this.setPreload(options.preload !== undefined ? options.preload : 0);
   this.setUseInterimTilesOnError(options.useInterimTilesOnError !== undefined ?
       options.useInterimTilesOnError : true);
+  this.setZDirection(options.zDirection);
 };
 goog.inherits(ol.layer.Tile, ol.layer.Layer);
 
@@ -96,4 +99,14 @@ ol.layer.Tile.prototype.getUseInterimTilesOnError = function() {
 ol.layer.Tile.prototype.setUseInterimTilesOnError = function(useInterimTilesOnError) {
   this.set(
       ol.layer.TileProperty.USE_INTERIM_TILES_ON_ERROR, useInterimTilesOnError);
+};
+
+
+ol.layer.Tile.prototype.getZDirection = function() {
+  return this.get(ol.layer.TileProperty.ZDIRECTION);
+};
+
+
+ol.layer.Tile.prototype.setZDirection = function(zDirection) {
+  this.set(ol.layer.TileProperty.ZDIRECTION, zDirection);
 };

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -59,7 +59,7 @@ ol.renderer.canvas.TileLayer = function(tileLayer) {
    * @protected
    * @type {number}
    */
-  this.zDirection = 0;
+  this.zDirection = tileLayer.getZDirection() !== undefined ? tileLayer.getZDirection() : 0;
 
 };
 goog.inherits(ol.renderer.canvas.TileLayer, ol.renderer.canvas.Layer);
@@ -243,7 +243,7 @@ ol.renderer.canvas.TileLayer.prototype.renderTileImages = function(context, fram
   if (rotation || hasRenderListeners) {
     renderContext = this.context;
     var renderCanvas = renderContext.canvas;
-    var drawZ = tileGrid.getZForResolution(resolution);
+    var drawZ = tileGrid.getZForResolution(resolution, this.zDirection);
     var drawTileSize = source.getTilePixelSize(drawZ, pixelRatio, projection);
     var tileSize = ol.size.toSize(tileGrid.getTileSize(drawZ));
     drawScale = drawTileSize[0] / tileSize[0];

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -57,6 +57,8 @@ ol.renderer.dom.TileLayer = function(tileLayer) {
    */
   this.tileLayerZs_ = {};
 
+  this.zDirection = tileLayer.getZDirection() !== undefined ? tileLayer.getZDirection() : 0;
+
 };
 goog.inherits(ol.renderer.dom.TileLayer, ol.renderer.dom.Layer);
 
@@ -93,7 +95,7 @@ ol.renderer.dom.TileLayer.prototype.prepareFrame = function(frameState, layerSta
   var tileSource = tileLayer.getSource();
   var tileGrid = tileSource.getTileGridForProjection(projection);
   var tileGutter = tileSource.getGutter(projection);
-  var z = tileGrid.getZForResolution(viewState.resolution);
+  var z = tileGrid.getZForResolution(viewState.resolution, this.zDirection);
   var tileResolution = tileGrid.getResolution(z);
   var center = viewState.center;
   var extent;

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -86,6 +86,8 @@ ol.renderer.webgl.TileLayer = function(mapRenderer, tileLayer) {
    */
   this.tmpSize_ = [0, 0];
 
+  this.zDirection = tileLayer.getZDirection() !== undefined ? tileLayer.getZDirection() : 0;
+
 };
 goog.inherits(ol.renderer.webgl.TileLayer, ol.renderer.webgl.Layer);
 
@@ -161,7 +163,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame = function(frameState, layerS
       'layer is an instance of ol.layer.Tile');
   var tileSource = tileLayer.getSource();
   var tileGrid = tileSource.getTileGridForProjection(projection);
-  var z = tileGrid.getZForResolution(viewState.resolution);
+  var z = tileGrid.getZForResolution(viewState.resolution, this.zDirection);
   var tileResolution = tileGrid.getResolution(z);
 
   var tilePixelSize =


### PR DESCRIPTION
By default, the OpenLayers renderer select the closest resolution if the
current resolution of the view does not exactly match a resolution of the
tile source. This could be a lower resolution leading to a worse image
quality.

To enforce the usage of the better quality / higher resolution tiles, the
`zDirection` option is introduced to the `TileLayer`.

This change is required to solve kitodo/kitodo-presentation#317.